### PR TITLE
Writefreely import

### DIFF
--- a/instances.ini
+++ b/instances.ini
@@ -1,0 +1,3 @@
+[writeas]
+url=https://write.as
+token=00000000-0000-0000-0000-000000000000

--- a/instances.ini
+++ b/instances.ini
@@ -1,3 +1,5 @@
+; each instance gets a [section]
+; each instance has a url and a token
 [writeas]
 url=https://write.as
 token=00000000-0000-0000-0000-000000000000

--- a/main.go
+++ b/main.go
@@ -223,7 +223,6 @@ func main() {
 	postsCount := 0
 
 	for _, ch := range d.Channels {
-		ch.Title = ch.Title + " " + store.GenerateFriendlyRandomString(4)
 		log.Printf("Channel: %s\n", ch.Title)
 
 		// Create the blog
@@ -234,7 +233,17 @@ func main() {
 		log.Printf("Creating %s...\n", ch.Title)
 		coll, err := cl.CreateCollection(c)
 		if err != nil {
-			errQuit(err.Error())
+			if err.Error() == "Collection name is already taken." {
+				newTitle := ch.Title + " " + store.GenerateFriendlyRandomString(4)
+				log.Printf("A blog by that name already exists. Changing to %s...\n", newTitle)
+				c.Title = newTitle
+				coll, err = cl.CreateCollection(c)
+				if err != nil {
+					errQuit(err.Error())
+				}
+			} else {
+				errQuit(err.Error())
+			}
 		}
 		log.Printf("Done!\n")
 

--- a/main.go
+++ b/main.go
@@ -266,7 +266,12 @@ func main() {
 			if tags != "" {
 				con += "\n\n" + tags
 			}
-
+			var postlang string
+			if len(ch.Language) > 2 {
+				postlang = string(ch.Language[:2])
+			} else {
+				postlang = ch.Language
+			}
 			p := &writeas.PostParams{
 				Title:      wpp.Title,
 				Slug:       wpp.PostName,
@@ -274,7 +279,7 @@ func main() {
 				Created:    &wpp.PostDateGmt,
 				Updated:    &wpp.PostDateGmt,
 				Font:       "norm",
-				Language:   &ch.Language,
+				Language:   &postlang,
 				Collection: coll.Alias,
 			}
 			log.Printf("Creating %s", p.Title)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"github.com/frankbille/go-wxr-import"
 	"github.com/writeas/godown"
+	"github.com/writeas/nerds/store"
 	"go.code.as/writeas.v2"
 	"io/ioutil"
 	"log"
@@ -222,6 +223,7 @@ func main() {
 	postsCount := 0
 
 	for _, ch := range d.Channels {
+		ch.Title = ch.Title + " " + store.GenerateFriendlyRandomString(4)
 		log.Printf("Channel: %s\n", ch.Title)
 
 		// Create the blog

--- a/main.go
+++ b/main.go
@@ -166,6 +166,8 @@ func main() {
 		t = val.Token
 		u = val.Url
 	}
+	// TODO: change this so it offers in-app authentication.
+	// Store URLS and tokens in instances.ini.
 	if t == "" {
 		errQuit("not authenticated. run: writeas auth <username>")
 	}

--- a/main.go
+++ b/main.go
@@ -193,7 +193,11 @@ func main() {
 		})
 		usr, uerr := cl.LogIn(uname, passwd)
 		if uerr != nil {
-			errQuit("Couldn't log in with those credentials.")
+			if err.Error == "Stop repeatedly trying to log in." {
+				errQuit("Stop repeatedly trying to log in.")
+			} else {
+				errQuit("Couldn't log in with those credentials.")
+			}
 		}
 		file, ferr = os.OpenFile("instances.ini", os.O_APPEND|os.O_WRONLY, 0644)
 		defer file.Close()

--- a/main.go
+++ b/main.go
@@ -118,8 +118,11 @@ func importConfig() map[string]instance {
 	newinst := instance{}
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
+		if line == "" {
+			continue
+		}
 		fc := string(line[0])
-		if line == "" || fc == ";" {
+		if fc == ";" {
 			continue
 		}
 		if fc == "[" {


### PR DESCRIPTION
Adapts the existing writeas import tool to work with any WriteFreely instance.

This tool will prompt for login information if the instance isn't stored in the included INI file. It also adds a "friendly" 4-character string to the end of each blog's name, to avoid collisions in the database.